### PR TITLE
Upgrade to ESLint@2.2.0.

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,3 +1,37 @@
 var fs = require('fs');
+var path = require('path');
 var config = require('./index');
-fs.writeFile("build/eslint.json", JSON.stringify(config), {encoding: 'utf8'});
+
+function makeDir(dir, callback) {
+  fs.mkdir(dir, (err) => {
+    if (err) {
+      throw err;
+    }
+
+    callback();
+  });
+}
+
+function writeJson(path) {
+  fs.writeFile(fullPath, JSON.stringify(config), {encoding: 'utf8'}, (err) => {
+    if (err) {
+      throw err;
+    }
+
+    console.log('Built');
+  });
+}
+
+// We can't write the build.json file if we don't have the `build` dir.
+const dir = "build";
+const jsonFile = "eslint.json";
+const fullPath = path.join(dir, jsonFile);
+
+fs.stat(dir, (err) => {
+  if (err) {
+    makeDir(dir, () => writeJson(fullPath));
+  }
+  else {
+    writeJson(fullPath);
+  }
+});

--- a/eslint.json
+++ b/eslint.json
@@ -1,29 +1,6 @@
 {
-  "ecmaFeatures": {
-    "arrowFunctions": true,
-    "binaryLiterals": true,
-    "blockBindings": true,
-    "classes": true,
-    "defaultParams": true,
-    "destructuring": true,
-    "forOf": true,
-    "generators": true,
-    "modules": true,
-    "objectLiteralComputedProperties": true,
-    "objectLiteralDuplicateProperties": true,
-    "objectLiteralShorthandMethods": true,
-    "objectLiteralShorthandProperties": true,
-    "octalLiterals": true,
-    "regexUFlag": true,
-    "regexYFlag": true,
-    "restParams": true,
-    "spread": true,
-    "superInFunctions": true,
-    "templateStrings": true,
-    "unicodeCodePointEscapes": true,
-    "globalReturn": true
-  },
   "env": {
+    "es6": true,
     "amd": false,
     "browser": false,
     "jasmine": false,
@@ -31,8 +8,13 @@
     "node": false
   },
   "parser": "espree",
+  "parserOptions": {
+      "ecmaVersion": 6,
+      "sourceType": "module"
+  },
   "rules": {
     "accessor-pairs": 2,
+    "array-callback-return": 2,
     "array-bracket-spacing": [
       2,
       "never"
@@ -94,6 +76,7 @@
     "global-require": 2,
     "guard-for-in": 2,
     "handle-callback-err": 0,
+    "id-blacklist": 0,
     "id-length": 0,
     "id-match": 0,
     "indent": [
@@ -141,15 +124,16 @@
     "new-cap": 2,
     "new-parens": 2,
     "newline-after-var": 2,
+    "newline-per-chained-call": 2,
     "no-alert": 2,
     "no-array-constructor": 2,
-    "no-arrow-condition": 2,
     "no-bitwise": 2,
     "no-caller": 2,
     "no-case-declarations": 2,
     "no-catch-shadow": 2,
     "no-class-assign": 2,
     "no-cond-assign": 2,
+    "no-confusing-arrow": 2,
     "no-const-assign": 2,
     "no-console": 2,
     "no-constant-condition": 2,
@@ -165,13 +149,15 @@
     "no-else-return": 2,
     "no-empty": 2,
     "no-empty-character-class": 2,
-    "no-empty-label": 2,
+    "no-empty-function": 2,
+    "no-labels": 2,
     "no-eq-null": 2,
     "no-eval": 2,
     "no-ex-assign": 2,
     "no-extend-native": 2,
     "no-extra-bind": 2,
     "no-extra-boolean-cast": 2,
+    "no-extra-label": 2,
     "no-extra-parens": [
       2,
       "functions"
@@ -182,6 +168,7 @@
     "no-func-assign": 2,
     "no-implied-eval": 2,
     "no-implicit-coercion": 2,
+    "no-implicit-globals": 2,
     "no-inline-comments": 0,
     "no-inner-declarations": [
       2,
@@ -192,7 +179,6 @@
     "no-iterator": 2,
     "no-invalid-this": 2,
     "no-label-var": 2,
-    "no-labels": 2,
     "no-lone-blocks": 2,
     "no-lonely-if": 2,
     "no-loop-func": 2,
@@ -221,6 +207,7 @@
     "no-new-func": 2,
     "no-new-object": 2,
     "no-new-require": 0,
+    "no-new-symbol": 0,
     "no-new-wrappers": 2,
     "no-obj-calls": 2,
     "no-octal": 2,
@@ -234,10 +221,12 @@
     "no-redeclare": 2,
     "no-regex-spaces": 2,
     "no-reserved-keys": 0,
+    "no-restricted-imports": 0,
     "no-restricted-modules": 0,
     "no-restricted-syntax": [2, "FunctionExpression", "WithStatement"],
     "no-return-assign": 2,
     "no-script-url": 2,
+    "no-self-assign": 2,
     "no-self-compare": 2,
     "no-sequences": 2,
     "no-shadow": 2,
@@ -254,9 +243,12 @@
     "no-undefined": 2,
     "no-underscore-dangle": 2,
     "no-unexpected-multiline": 2,
+    "no-useless-constructor": 2,
+    "no-unmodified-loop-condition": 2,
     "no-unneeded-ternary": 2,
     "no-unreachable": 2,
     "no-unused-expressions": 2,
+    "no-unused-labels": 2,
     "no-unused-vars": [
       2,
       {
@@ -280,6 +272,7 @@
         ]
       }
     ],
+    "no-whitespace-before-property": 2,
     "no-with": 2,
     "object-curly-spacing": [
       2,
@@ -287,6 +280,7 @@
     ],
     "object-shorthand": 0,
     "one-var": 0,
+    "one-var-declaration-per-line": 0,
     "operator-assignment": [
       0,
       "always"
@@ -299,6 +293,7 @@
     "prefer-arrow-callback": 2,
     "prefer-const": 2,
     "prefer-reflect": 2,
+    "prefer-rest-params": 2,
     "prefer-spread": 2,
     "prefer-template": 2,
     "quote-props": [
@@ -320,11 +315,8 @@
         "before": false
       }
     ],
+    "sort-imports": 0,
     "sort-vars": 0,
-    "space-after-keywords": [
-      2,
-      "always"
-    ],
     "space-before-blocks": [
       2,
       "always"
@@ -336,13 +328,12 @@
         "named": "never"
       }
     ],
-    "space-before-keywords": [2, "always"],
+    "keyword-spacing": 2,
     "space-in-parens": [
       2,
       "never"
     ],
     "space-infix-ops": 2,
-    "space-return-throw-case": 2,
     "space-unary-ops": [
       2,
       {
@@ -358,6 +349,7 @@
       2,
       "global"
     ],
+    "template-curly-spacing": 2,
     "use-isnan": 2,
     "valid-jsdoc": 2,
     "valid-typeof": 2,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ava": "^0.10.0",
     "babel-register": "^6.4.3",
     "chai": "^2.3.0",
-    "eslint": "^1.7.3",
-    "eslint-code-review": "0.1.0"
+    "eslint": "^2.2.0",
+    "eslint-code-review": "0.1.1"
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "../build/eslint.json"
+  "extends": "../eslint.json"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,7 @@ test('Check output', (t) => {
 
   `;
   const messages = new CodeChecker(code, config);
+
   t.is(messages.length, 3);
   t.ok(messages.ruleMatch('prefer-const'));
   t.ok(messages.ruleMatch('no-console'));


### PR DESCRIPTION
- Updated `eslint.json` to use ESLint 2 approach to ECMAScript features,
  and added es6 environment settings.
- Enabled `build.js` to handle a missing `build` dir.

Resolves #2
